### PR TITLE
Support keyword arguments, issue #2

### DIFF
--- a/mock/private/base.rkt
+++ b/mock/private/base.rkt
@@ -11,7 +11,7 @@
   [mock? predicate/c]
   [make-mock (-> procedure? mock?)]
   [mock-calls (-> mock? (listof mock-call?))]
-  [struct mock-call ([args list?] [result any/c])]
+  [struct mock-call ([args list?] [results list?])]
   [mock-called-with? (-> list? mock? boolean?)]
   [mock-num-calls (-> mock? exact-nonnegative-integer?)]))
 
@@ -19,16 +19,17 @@
 (struct mock (proc calls-box)
   #:property prop:procedure (struct-field-index proc))
 
-(struct mock-call (args result) #:prefab)
+(struct mock-call (args results) #:prefab)
 
 (define (make-mock proc)
   (define calls (box '()))
   (define (add-call! call)
     (set-box! calls (cons call (unbox calls))))
   (define (wrapper . vs)
-    (define result (apply proc vs))
-    (add-call! (mock-call vs result))
-    result)
+    (define results (call-with-values (λ _ (apply proc vs))
+                                      list))
+    (add-call! (mock-call vs results))
+    (apply values results))
   (mock wrapper calls))
 
 (define (mock-calls mock)

--- a/mock/private/base.scrbl
+++ b/mock/private/base.scrbl
@@ -24,12 +24,14 @@
     (define displayln-mock (make-mock displayln))
     (displayln-mock "foo")
     (mock? displayln-mock)
+    (define quotient/remainder-mock (make-mock quotient/remainder))
+    (quotient/remainder-mock 10 3)
 ]}
 
-@defstruct*[mock-call ([args list?] [result any/c])
+@defstruct*[mock-call ([args list?] [results list?])
             #:prefab]{
   A prefab structure containg the arguments and result
-  of a single call to a @racket[mock?].
+  values of a single call to a @racket[mock?].
 }
 
 @defproc[(mock-calls [mock mock?]) (listof mock-call?)]{
@@ -40,6 +42,10 @@
     (mock-calls displayln-mock)
     (displayln-mock "foo")
     (mock-calls displayln-mock)
+    (define quotient/remainder-mock (make-mock quotient/remainder))
+    (quotient/remainder-mock 10 3)
+    (quotient/remainder-mock 3 2)
+    (mock-calls quotient/remainder-mock)
 ]}
 
 @defproc[(mock-called-with? [args list?] [mock mock?])

--- a/mock/private/base.scrbl
+++ b/mock/private/base.scrbl
@@ -53,11 +53,20 @@
   Returns @racket[#t] if @racket[mock] has ever been
   called with arguments that are @racket[equal?] to
   @racket[args], returns @racket[#f] otherwise.
+
+  In the list of arguments, supply by-position argument values
+  first, in order. Then supply keyword arguments, in any order.
+  Supply each keyword as a two-element list: @racket[(#:keyword value)].
   @mock-examples[
     (define displayln-mock (make-mock displayln))
     (mock-called-with? '("foo") displayln-mock)
     (displayln-mock "foo")
     (mock-called-with? '("foo") displayln-mock)
+    (require racket/format)
+    (define ~a-mock (make-mock ~a))
+    (~a-mock 0 #:width 3 #:align 'left)
+    (mock-called-with? '(0 [#:align left] [#:width 3]) ~a-mock)
+    (mock-called-with? '(0 [#:width 3] [#:align left]) ~a-mock)
 ]}
 
 @defproc[(mock-num-calls [mock mock?])


### PR DESCRIPTION
This records keyword argument values as `[#:keyword value]` within the argument list. It requires the user to supply them to `mock-called-with?` in that same format. However it doesn't require the user to present the keywords sorted by keyword name.

I thought about doing it `... ...` style, but it seemed like it might not be worth the effort.

Note: I created this branch off the `multiple-values` branch, and so below you see the commit in my previous pull request. IIUC it will work fine if you simply merge both in order. But if I messed up, let me know and I'm happy to rebase or do whatever might be required.
