### PR TITLE
Add dependency on unstable-lib.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -12,7 +12,8 @@
     "fancy-app"
     "rackunit-lib"
     "scribble-lib"
-    "sweet-exp"))
+    "sweet-exp"
+    "unstable-lib"))
 
 
 (define build-deps


### PR DESCRIPTION
Fixes this package for Racket 6.3.

In the future, you may want to replace the dependency on `unstable/sequence`.
