### PR TITLE
check-mock-num-calls prints expected and actual

### DIFF
--- a/mock/private/check.rkt
+++ b/mock/private/check.rkt
@@ -19,6 +19,10 @@ provide
         (fail-check "Actual arguments did not match expected")))))
 
 
-(define-simple-check (check-mock-num-calls expected-num-calls mock)
-  (equal? (mock-num-calls mock) expected-num-calls))
+(define-check (check-mock-num-calls expected-num-calls mock)
+  (let ([result (equal? (mock-num-calls mock) expected-num-calls)])
+    (with-check-info
+      [('expected expected-num-calls) ('actual (mock-num-calls mock))]
+      (unless result
+        (fail-check "Actual amount of calls did not match expected")))))
 

--- a/mock/private/tests/check-tests.rkt
+++ b/mock/private/tests/check-tests.rkt
@@ -1,0 +1,28 @@
+#lang sweet-exp racket
+
+require rackunit
+        mock
+
+(define (has-info? check-failure info-name)
+  (member info-name (map check-info-name (exn:test:check-stack check-failure))))
+
+(module+ test
+  (test-case
+    "check-mock-num-calls does not fail when amount of calls is equal"
+    (check-mock-num-calls 0 (void-mock)))
+
+  (test-case
+    "check-info is added by check-mock-num-calls? on failure"
+    (check-exn
+      (λ (e) (and (has-info? e 'expected) (has-info? e 'actual)))
+      (thunk
+        (parameterize ([current-check-handler raise])
+          (check-mock-num-calls 1 (void-mock))))))
+
+  (test-case
+    "check-info is added by check-mock-called-with? on failure"
+    (check-exn
+      (λ (e) (and (has-info? e 'expected) (has-info? e 'actual)))
+      (thunk
+        (parameterize ([current-check-handler raise])
+          (check-mock-called-with? '(1) (void-mock)))))))


### PR DESCRIPTION
same as https://github.com/jackfirth/racket-mock/pull/19 but for check-mock-num-calls expected-num-calls

before:

```
test that displayln is called 2 times
FAILURE
name:       check-mock-num-calls
location:   /home/vdloo/.racket/6.2.1/pkgs/jack-mock/mock/private/check.rkt:11:4
params:     2
#<procedure:...t/private/kw.rkt:213:14>
Check failure
```

after:

```
test that displayln is called 2 times
FAILURE
name:       check-mock-num-calls
location:   /home/vdloo/.racket/6.2.1/pkgs/jack-mock/mock/private/check.rkt:11:4
actual:     1
expected:   2
Actual amount of calls did not match expected
```
