### PR TITLE
Add side effects procedure to make-mock

### DIFF
--- a/mock/private/base.rkt
+++ b/mock/private/base.rkt
@@ -9,7 +9,7 @@ require racket/bool
 provide
   contract-out
     mock? predicate/c
-    make-mock (-> procedure? mock?)
+    make-mock (->* (procedure?) (procedure?) mock?)
     mock-calls (-> mock? (listof mock-call?))
     struct mock-call ([args list?] [results list?])
     mock-called-with? (-> list? mock? boolean?)
@@ -26,7 +26,7 @@ provide
   (define-values (req-kws all-kws) (procedure-keywords proc-to-wrap))
   (procedure-reduce-keyword-arity wrapper-proc arity req-kws all-kws))
 
-(define (make-mock proc)
+(define (make-mock proc [results-proc proc])
   (define calls (box '()))
   (define (add-call! call)
     (set-box! calls (cons call (unbox calls))))
@@ -34,7 +34,7 @@ provide
     (make-keyword-procedure
      (λ (kws kw-vs . vs)
        (define results
-         (call-with-values (λ _ (keyword-apply proc kws kw-vs vs))
+         (call-with-values (λ _ (keyword-apply results-proc kws kw-vs vs))
                            list))
        (define all-vs (append vs (map list kws kw-vs)))
        (add-call! (mock-call all-vs  results))


### PR DESCRIPTION
Add an optional argument to `make-mock` that generates side-effects, instead of passing all calls to the mocked procedure. This is useful in case the mocked procedure creates side effects that have to be avoided during testing, e.g. connecting to a remote server, writing to a database, removing files from the filesystem ... 

By default, this procedure is the same as the mocked procedure, so this change should be transparent to all existing client code.
