### PR TITLE
Add parameterizable mocks

### DIFF
--- a/mock/private/base.rkt
+++ b/mock/private/base.rkt
@@ -70,7 +70,7 @@ module+ test
   (check-true (mock-called-with? m '(0) (hash '#:align 'left '#:width 3)))
   (check-false (mock-called-with? m '(42) (hash))))
 
-(define-simple-macro (with-mock-behavior ([mock:id new-behavior:expr] ...) body ...)
+(define-simple-macro (with-mock-behavior ([mock:expr new-behavior:expr] ...) body ...)
   (parameterize ([(mock-behavior mock) new-behavior] ...) body ...))
 
 (module+ test

--- a/mock/private/base.rkt
+++ b/mock/private/base.rkt
@@ -29,14 +29,15 @@ module+ test
 (define-syntax-rule (with-values-as-list body ...)
   (call-with-values (thunk body ...) list))
 
+(define (kws+vs->kwargs kws vs) (make-immutable-hash (map cons kws vs)))
+
 (define call-mock-behavior
   (make-keyword-procedure
    (λ (kws kw-vs a-mock . vs)
      (match-define (mock current-behavior calls-box) a-mock)
      (define results
        (with-values-as-list (keyword-apply (current-behavior) kws kw-vs vs)))
-     (define kwargs (make-immutable-hash (map cons kws kw-vs)))
-     (add-call! calls-box (mock-call vs kwargs results))
+     (add-call! calls-box (mock-call vs (kws+vs->kwargs kws kw-vs) results))
      (apply values results))))
 
 (struct mock-call (args kwargs results) #:transparent)

--- a/mock/private/base.rkt
+++ b/mock/private/base.rkt
@@ -1,14 +1,9 @@
 #lang sweet-exp racket/base
 
-require fancy-app
-        racket/bool
-        racket/contract
-        racket/function
-        racket/splicing
-        rackunit
-        unstable/sequence
+require racket/contract/base
 
 provide
+  with-mock-behavior
   contract-out
     mock? predicate/c
     make-mock (-> procedure? mock?)
@@ -17,54 +12,55 @@ provide
     mock-called-with? (-> mock? list? (hash/c keyword? any/c) boolean?)
     mock-num-calls (-> mock? exact-nonnegative-integer?)
 
+require fancy-app
+        racket/match
+        racket/function
+        rackunit
+        syntax/parse/define
+
 module+ test
   require rackunit
           racket/format
 
 
-(struct mock (proc calls-box)
-  #:property prop:procedure (struct-field-index proc))
-
-(struct mock-call (args kwargs results) #:transparent)
-
-(define (ensure-same-keyword-arity proc-to-wrap wrapper-proc)
-  (define arity (procedure-arity proc-to-wrap))
-  (define-values (req-kws all-kws) (procedure-keywords proc-to-wrap))
-  (procedure-reduce-keyword-arity wrapper-proc arity req-kws all-kws))
-
 (define (box-transform! a-box f)
   (set-box! a-box (f (unbox a-box))))
 
-(define (make-mock proc)
-  (define calls (box '()))
-  (define (add-call! call) (box-transform! calls (append _ (list call))))
-  (define wrapper
-    (make-keyword-procedure
-     (λ (kws kw-vs . vs)
-       (define results
-         (call-with-values (thunk (keyword-apply proc kws kw-vs vs))
-                           list))
-       (define kwargs (make-immutable-hash (map cons kws kw-vs)))
-       (add-call! (mock-call vs kwargs results))
-       (apply values results))))
-  (mock (ensure-same-keyword-arity proc wrapper) calls))
+(define-syntax-rule (with-values-as-list body ...)
+  (call-with-values (thunk body ...) list))
 
-(define mock-calls (compose unbox mock-calls-box))
+(define call-mock-behavior
+  (make-keyword-procedure
+   (λ (kws kw-vs a-mock . vs)
+     (match-define (mock current-behavior calls-box) a-mock)
+     (define results
+       (with-values-as-list (keyword-apply (current-behavior) kws kw-vs vs)))
+     (define kwargs (make-immutable-hash (map cons kws kw-vs)))
+     (add-call! calls-box (mock-call vs kwargs results))
+     (apply values results))))
+
+(struct mock-call (args kwargs results) #:transparent)
+(struct mock (behavior calls-box)
+  #:property prop:procedure call-mock-behavior)
+
+(define (add-call! calls-box call)
+  (box-transform! calls-box (append _ (list call))))
+
+(define (make-mock proc)
+  (mock (make-parameter proc) (box '())))
 
 (define (mock-called-with? mock args kwargs)
   (for/or ([call (in-list (mock-calls mock))])
     (and (equal? args (mock-call-args call))
          (equal? kwargs (mock-call-kwargs call)))))
 
+(define mock-calls (compose unbox mock-calls-box))
 (define mock-num-calls (compose length mock-calls))
 
 (module+ test
   (define m (make-mock ~a))
-  (check-equal? (call-with-values (λ _ (procedure-keywords ~a)) list)
-                (call-with-values (λ _ (procedure-keywords m)) list))
   (check-equal? (m 0) "0")
   (check-equal? (m 0 #:width 3 #:align 'left) "0  ")
-  
   (check-equal? (mock-calls m)
                 (list (mock-call '(0) (hash) '("0"))
                       (mock-call '(0) (hash '#:width 3 '#:align 'left) '("0  "))))
@@ -72,3 +68,12 @@ module+ test
   (check-true (mock-called-with? m '(0) (hash)))
   (check-true (mock-called-with? m '(0) (hash '#:align 'left '#:width 3)))
   (check-false (mock-called-with? m '(42) (hash))))
+
+(define-simple-macro (with-mock-behavior ([mock:id new-behavior:expr] ...) body ...)
+  (parameterize ([(mock-behavior mock) new-behavior] ...) body ...))
+
+(module+ test
+  (define num-proc-mock (make-mock add1))
+  (check-equal? (num-proc-mock 0) 1)
+  (with-mock-behavior ([num-proc-mock sub1])
+    (check-equal? (num-proc-mock 0) -1)))

--- a/mock/private/base.scrbl
+++ b/mock/private/base.scrbl
@@ -25,6 +25,21 @@
  (mock? quotient/remainder-mock)
  ]}
 
+@defform[(with-mock-behavior ([mock-expr proc-expr] ...) body ...)
+         #:contracts ([mock-expr mock?] [proc-expr procedure?])]{
+ Evaluates each @racket[mock-expr] and @racket[proc-expr] which must
+ be a @racket[mock?] and a @racket[procedure?], then alters the mock's
+ behavior in the dynamic extent of @racket[(body ...)] to the given
+ procedure. This allows the same mock to behave differently between
+ calls, which is useful for @racket[define/mock].
+ @mock-examples[
+ (define a-mock (make-mock add1))
+ (a-mock 10)
+ (with-mock-behavior ([a-mock sub1])
+   (a-mock 10))
+ (a-mock 10)
+ (mock-calls a-mock)]}
+
 @defstruct*[mock-call ([args list?] [kwargs (hash/c keyword? any/c)] [results list?]) #:transparent]{
  A structure containg the arguments and result
  values of a single call to a @racket[mock?].


### PR DESCRIPTION
Allows mocks to have their behavior changed after creation. Considered use case is changing a mock made in `define/mock` to behave differently in different tests. Future work for supporting this use case includes allowing mocks to be reset. This PR also includes default mock behavior, a future PR will properly document that.
