### PR TITLE
Add an arguments structure

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection 'multi)
-(define version "0.4")
+(define version "0.5")
 (define deps
   '(("base" #:version "6.4")
     "fancy-app"

--- a/mock/main.rkt
+++ b/mock/main.rkt
@@ -1,4 +1,5 @@
-#lang reprovide
+#lang sweet-exp reprovide
+except-in "private/args.rkt" kws+vs->hash
 "private/base.rkt"
 "private/check.rkt"
 "private/syntax.rkt"

--- a/mock/main.scrbl
+++ b/mock/main.scrbl
@@ -16,5 +16,6 @@ testing code that calls side-effectful operations and IO.
 source code: @url["https://github.com/jackfirth/racket-mock"]
 
 @include-section["private/base.scrbl"]
+@include-section["private/args.scrbl"]
 @include-section["private/check.scrbl"]
 @include-section["private/syntax.scrbl"]

--- a/mock/private/args.rkt
+++ b/mock/private/args.rkt
@@ -59,11 +59,7 @@ module+ test
 
 (define (format-keyword-args-message kwargs)
   (apply string-append
-         (hash-map kwargs (format "\n   ~a: ~v" _ _) #t)))
-
-(module+ test
-  (check-equal? (format-keyword-args-message (hash '#:foo 'bar '#:baz "blah"))
-                "\n   #:baz: \"blah\"\n   #:foo: 'bar"))
+         (hash-map kwargs (format "\n   ~a: ~v" _ _))))
 
 (struct exn:fail:unexpected-arguments exn:fail (args) #:transparent)
 (define unexpected-call-message-format

--- a/mock/private/args.rkt
+++ b/mock/private/args.rkt
@@ -1,0 +1,83 @@
+#lang sweet-exp racket/base
+
+require racket/contract/base
+
+provide
+  contract-out
+    keyword-hash? flat-contract?
+    kws+vs->hash (-> (listof keyword?) list? keyword-hash?)
+    arguments? predicate/c
+    arguments-positional (-> arguments? list?)
+    arguments-keyword (-> arguments? keyword-hash?)
+    arguments (unconstrained-domain-> arguments?)
+    make-arguments (-> list? keyword-hash? arguments?)
+    struct (exn:fail:unexpected-arguments exn:fail)
+      ([message string?]
+       [continuation-marks continuation-mark-set?]
+       [args arguments?])
+    make-raise-unexpected-arguments-exn (-> string? procedure?)
+
+require fancy-app
+
+module+ test
+  require rackunit
+
+(define keyword-hash? (hash/c keyword? any/c #:immutable #t #:flat? #t))
+
+(module+ test
+  (check-true (keyword-hash? (hash '#:foo 'bar '#:baz "blah")))
+  (check-false (keyword-hash? (make-hash '((#:foo . bar) (#:baz . "blah")))))
+  (check-false (keyword-hash? (hash '#:foo 'bar '#:baz "blah" 0 1))))
+
+(define (kws+vs->hash kws vs) (make-immutable-hash (map cons kws vs)))
+
+(struct arguments (positional keyword)
+  #:transparent
+  #:constructor-name make-arguments
+  #:omit-define-syntaxes)
+
+(define arguments
+  (make-keyword-procedure
+   (λ (kws kw-vs . vs)
+     (make-arguments vs (kws+vs->hash kws kw-vs)))))
+
+(module+ test
+  (check-equal? (arguments) (make-arguments '() (hash)))
+  (check-equal? (arguments 1 2 3) (make-arguments '(1 2 3) (hash)))
+  (check-equal? (arguments #:foo 'bar #:baz "blah")
+                (make-arguments '() (hash '#:foo 'bar '#:baz "blah")))
+  (check-equal? (arguments 1 2 3 #:foo 'bar #:baz "blah")
+                (make-arguments '(1 2 3) (hash '#:foo 'bar '#:baz "blah"))))
+
+(define (format-positional-args-message args)
+  (apply string-append
+         (map (format "\n   ~v" _) args)))
+
+(module+ test
+  (check-equal? (format-positional-args-message '(1 foo "blah"))
+                "\n   1\n   'foo\n   \"blah\""))
+
+(define (format-keyword-args-message kwargs)
+  (apply string-append
+         (hash-map kwargs (format "\n   ~a: ~v" _ _) #t)))
+
+(module+ test
+  (check-equal? (format-keyword-args-message (hash '#:foo 'bar '#:baz "blah"))
+                "\n   #:baz: \"blah\"\n   #:foo: 'bar"))
+
+(struct exn:fail:unexpected-arguments exn:fail (args) #:transparent)
+(define unexpected-call-message-format
+  "~a: unexpectedly called with arguments\n  positional: ~a\n  keyword: ~a")
+
+(define (make-raise-unexpected-arguments-exn source-name)
+  (make-keyword-procedure
+   (λ (kws kw-vs . vs)
+     (define kwargs (kws+vs->hash kws kw-vs))
+     (define message
+       (format unexpected-call-message-format
+               source-name
+               (format-positional-args-message vs)
+               (format-keyword-args-message kwargs)))
+     (raise
+      (exn:fail:unexpected-arguments
+       message (current-continuation-marks) (make-arguments vs kwargs))))))

--- a/mock/private/args.scrbl
+++ b/mock/private/args.scrbl
@@ -1,0 +1,51 @@
+#lang scribble/manual
+@(require "util/doc.rkt")
+
+@title{Arguments structure}
+Mocks record procedure calls partly via an @racket[arguments] structure.
+Various utility procedures for constructing and manipulating these structures
+are provided by @racketmodname[mock].
+
+@deftogether[
+ (@defthing[#:kind "value" arguments? predicate/c]
+  @defproc[(arguments-positional [arguments arguments?]) list?]
+  @defproc[(arguments-keyword [arguments arguments?]) keyword-hash?])]{
+ Predicate and accessors for values returned by @racket[make-arguments] and
+ @racket[arguments].
+}
+
+@defproc[(make-arguments [positional list?] [keyword keyword-hash?]) arguments?]{
+ Returns a value representing the arguments of a procedure call where @racket[positional]
+ ontains the given positional arguments, and @racket[keyword] contains the given keyword
+ arguments.
+ @mock-examples[
+ (make-arguments '(1 2 3) (hash '#:foo "bar"))]}
+
+@defthing[#:kind "procedure" arguments (unconstrained-domain-> arguments?)]{
+ A procedure that collects all arguments it's called with into an @racket[arguments]
+ structure. Accepts both positional and keyword arguments.
+ @mock-examples[
+ (arguments 1 2 3 #:foo "bar")]}
+
+@defthing[#:kind "value" keyword-hash? flat-contract?]{
+ A flat contract that recognizes immutable hashes whose keys are keywords. Equivalent
+ to @racket[(hash/c keyword? any/c #:flat? #t #:immutable #t)].
+ @mock-examples[
+ (keyword-hash? (hash '#:foo "bar"))
+ (keyword-hash? (make-hash '((#:foo . "bar"))))
+ (keyword-hash? (hash 'foo "bar"))]}
+
+@defproc[(make-raise-unexpected-arguments-exn [source-name string?]) procedure?]{
+ Returns a procedure that accepts any number of positional or keyword arguments
+ and always @racket[raise]s @racket[exn:fail:unexpected-call] with @racket[name] as
+ the name used to report the error. This is the default behavior for mocks, see
+ @racket[make-mock]. The exception message details each positional and keyword
+ argument given.
+ @mock-examples[
+ (define uncallable (make-raise-unexpected-arguments-exn "example"))
+ (eval:error (uncallable 5 #:foo 'bar))]}
+
+@defstruct*[(exn:fail:unexpected-arguments exn:fail)
+            ([args list?] [kwargs (hash/c keyword? any/c)])
+            #:transparent]{
+ An exception type used by mocks that don't expect to be called at all.}

--- a/mock/private/check.rkt
+++ b/mock/private/check.rkt
@@ -1,22 +1,20 @@
 #lang sweet-exp racket/base
 
-require racket/bool
-        racket/contract
+require racket/contract
         rackunit
+        "args.rkt"
         "base.rkt"
 
 provide
   contract-out
-    check-mock-called-with? (-> mock? list? (hash/c keyword? any/c) void?)
+    check-mock-called-with? (-> mock? arguments? void?)
     check-mock-num-calls (-> exact-nonnegative-integer? mock? void?)
 
 
-(define-check (check-mock-called-with? mock args kwargs)
-  (define result (mock-called-with? mock args kwargs))
+(define-check (check-mock-called-with? mock args)
   (with-check-info (['expected-args args]
-                    ['expected-kwargs kwargs]
                     ['actual-calls (mock-calls mock)])
-    (unless result
+    (unless (mock-called-with? mock args)
       (fail-check "No calls were made matching the expected arguments"))))
 
 (define-simple-check (check-mock-num-calls expected-num-calls mock)

--- a/mock/private/check.scrbl
+++ b/mock/private/check.scrbl
@@ -12,9 +12,9 @@
  has never been called with @racket[args] and @racket[kwargs].
  @mock-examples[
  (define mock (make-mock void))
- (check-mock-called-with? mock '(foo) (hash))
+ (check-mock-called-with? mock (arguments 'foo))
  (mock 'foo)
- (check-mock-called-with? mock '(foo) (hash))]}
+ (check-mock-called-with? mock (arguments 'foo))]}
 
 @defproc[(check-mock-num-calls [n exact-positive-integer?] [mock mock?])
          void?]{


### PR DESCRIPTION
Closes #29.
Closes #13.

Makes many mock functions easier to implement and call.
