### PR TITLE
Add mock names for error messages

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection 'multi)
-(define version "0.5")
+(define version "0.6")
 (define deps
   '(("base" #:version "6.4")
     "fancy-app"

--- a/mock/private/check.scrbl
+++ b/mock/private/check.scrbl
@@ -11,17 +11,17 @@
  A @racketmodname[rackunit] check that fails if @racket[mock]
  has never been called with @racket[args] and @racket[kwargs].
  @mock-examples[
- (define mock (make-mock void))
- (check-mock-called-with? mock (arguments 'foo))
- (mock 'foo)
- (check-mock-called-with? mock (arguments 'foo))]}
+ (define a-mock (mock #:behavior void))
+ (check-mock-called-with? a-mock (arguments 'foo))
+ (a-mock 'foo)
+ (check-mock-called-with? a-mock (arguments 'foo))]}
 
 @defproc[(check-mock-num-calls [n exact-positive-integer?] [mock mock?])
          void?]{
  A @racketmodname[rackunit] check that fails if @racket[mock]
  hasn't been called exactly @racket[n] times.
  @mock-examples[
- (define mock (make-mock void))
- (check-mock-num-calls 1 mock)
- (mock 'foo)
- (check-mock-num-calls 1 mock)]}
+ (define a-mock (mock #:behavior void))
+ (check-mock-num-calls 1 a-mock)
+ (a-mock 'foo)
+ (check-mock-num-calls 1 a-mock)]}

--- a/mock/private/syntax.rkt
+++ b/mock/private/syntax.rkt
@@ -25,8 +25,8 @@ provide define/mock
              (or (attribute given-submod-id) #'id)
              #:attr mock-value
              (if (attribute given-behavior)
-                 #'(make-mock given-behavior)
-                 #'(make-mock))
+                 #'(mock #:name (symbol->string 'submod-id) #:behavior given-behavior)
+                 #'(mock #:name (symbol->string 'submod-id)))
              #:attr explicit-form
              #'(id submod-id mock-value)))
   (define-syntax-class explicit-mock-clause


### PR DESCRIPTION
Closes #28.
Closes #35.

Also changes make-mock to mock and makes it accept optional keyword
arguments.
