### PR TITLE
Add Guide and move current docs to Reference

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection "mock")
-(define scribblings '(("main.scrbl" () (library) "mock")))
+(define scribblings '(("main.scrbl" (multi-page) (library) "mock")))
 (define version "0.9")
 (define deps
   '(("base" #:version "6.4")

--- a/main.scrbl
+++ b/main.scrbl
@@ -1,7 +1,7 @@
 #lang scribble/manual
 @(require "private/util-doc.rkt")
 
-@title{Mocks}
+@title[#:style '(toc)]{Mocks}
 @defmodule[mock #:packages ("jack-mock")]
 @author[@author+email["Jack Firth" "jackhfirth@gmail.com"]]
 
@@ -16,9 +16,6 @@ side effects like mutation and IO.
 
 source code: @url["https://github.com/jackfirth/racket-mock"]
 
-@include-section["private/base.scrbl"]
-@include-section["private/args.scrbl"]
-@include-section["private/check.scrbl"]
-@include-section["private/opaque.scrbl"]
-@include-section["private/syntax.scrbl"]
-@include-section["private/stub.scrbl"]
+@table-of-contents[]
+@include-section["private/guide.scrbl"]
+@include-section["private/reference.scrbl"]

--- a/private/guide.scrbl
+++ b/private/guide.scrbl
@@ -7,3 +7,104 @@ This guide is intended for programmers who are familiar with Racket but new to w
 with @mock-tech{mocks}. It contains a description of the high level concepts associated
 with the @racketmodname[mock] library, as well as examples and use cases. For a complete
 description of the @racketmodname[mock] API, see @secref{mock-reference}.
+
+@table-of-contents[]
+
+@section{Introduction to Mocks}
+@define-persistent-mock-examples[mock-intro-examples]
+
+The @racketmodname[mock] library defines @mock-tech{mocks}, procedures that record how
+they're used and can have their response to calls dynamically altered. Mocks are most
+useful when testing imperative code or code with side effects, serving as "fake"
+implementations in tests for verifying real implementations are used correctly. For
+example, how would one test this procedure?
+
+@mock-intro-examples[
+ (define (call/secret proc)
+   (proc "secret")
+   (void))]
+
+Howw can a test verify that the secret value is passed correctly? It would be one thing
+if @racket[call/secret] returned the result of the call, then we could simply pass in
+@racket[values] and verify that the whole thing returns @racket["secret"]. But because
+the result of the call is discarded, we somehow need to use a procedure that records a
+history of all calls made with it and then check that history after the fact. This is
+precisely what mocks are for.
+
+@mock-intro-examples[
+ (define secret-mock (mock #:behavior void))
+ (call/secret secret-mock)
+ (mock-calls secret-mock)]
+
+Mocks are constructed by the @racket[mock] function. They're procedures that behave
+exactly like whatever their current @behavior-tech{behavior} is, but they also keep a
+record of all calls made with them. In the previous example, we construct the mock
+@racket[secret-mock] that behaves like the @racket[void] procedure. If the behavior is
+unspecified the mock will throw an error whenver its called, so we choose @racket[void]
+as its behavior since @racket[call/secret] doesn't need a return value from the procedure
+it's given. After evaluating @racket[(call/secret secret-mock)], the @racket[secret-mock]
+has a procedure call in its saved history that is accessible via @racket[mock-calls]. Now
+we can query this history in tests. We can also clear a mock's history of calls using
+@racket[mock-reset!], allowing us to clean up after a test.
+
+@mock-intro-examples[
+ (mock-num-calls secret-mock)
+ (mock-reset! secret-mock)
+ (mock-num-calls secret-mock)]
+
+@section{Using Mocks in Place of Dependencies}
+@define-persistent-mock-examples[mock-deps-examples]
+
+In the previous section we used mocks to test a higher order function @racket[call/secret].
+Mocks also help when dealing with code that performs operations with side effects. In
+tests, we simply replace the operation procedure with a mock. To do this, we can take a
+procedure that calls side effectful dependencies and convert it to a higher order procedure
+like @racket[call/secret], which accepts the side effectful dependencies as inputs. Consider
+a procedure that looks up a favorite color from a file, then prints a message based on that
+color.
+
+@mock-deps-examples[
+ (define (print-favorite-color-message)
+   (define color (file->string "color-preference.txt"))
+   (define message
+     (case color
+       [("blue") "Your favorite color is blue. Like the ocean!"]
+       [("red") "Your favorite color is red. Fiery, fiery red!"]
+       [("green") "Your favorite color is green. I love forests!"]
+       [else "I haven't got much to say about your favorite color."]))
+   (displayln message))]
+
+Testing this procedure is definitely tricky. There's input from the
+@racket["color-preferences.txt"] file to worry about along with output via
+@racket[displayln]. To properly test this procedure, let's alter it slightly.
+We'll pass in the side effectful dependency procedures as arguments.
+
+@mock-deps-examples[
+ (define (print-favorite-color-message #:read-with [file->string file->string]
+                                       #:print-with [displayln displayln])
+   (define color (file->string "color-preference.txt"))
+   (define message
+     (case color
+       [("blue") "Your favorite color is blue. Like the ocean!"]
+       [("red") "Your favorite color is red. Fiery, fiery red!"]
+       [("green") "Your favorite color is green. I love forests!"]
+       [else "I haven't got much to say about your favorite color."]))
+   (displayln message))]
+
+Much better. By passing in the procedures we use for reading and writing as
+arguments, we allow tests to specify that input and output should be performed
+with mocks. Using the real functions by default also means we don't affect any
+existing code using @racket[print-favorite-color-message]. Now let's try using
+mocks.
+
+@mock-deps-examples[
+ (define file-mock (mock #:behavior (const "green")))
+ (define displayln-mock (mock #:behavior void))
+ (print-favorite-color-message #:read-with file-mock #:print-with displayln-mock)
+ (mock-calls file-mock)
+ (mock-calls displayln-mock)]
+
+By using @racket[const] we're able to easily setup tests that exercise a
+particular codepath. We can test side effectful code! There's still more to
+discuss, the following sections discuss adjusting mock behavior and automatically
+mocking out dependencies.

--- a/private/guide.scrbl
+++ b/private/guide.scrbl
@@ -1,0 +1,9 @@
+#lang scribble/manual
+@(require "util-doc.rkt")
+
+@title[#:tag "mock-guide"]{The Mock Guide}
+
+This guide is intended for programmers who are familiar with Racket but new to working
+with @mock-tech{mocks}. It contains a description of the high level concepts associated
+with the @racketmodname[mock] library, as well as examples and use cases. For a complete
+description of the @racketmodname[mock] API, see @secref{mock-reference}.

--- a/private/reference.scrbl
+++ b/private/reference.scrbl
@@ -1,0 +1,15 @@
+#lang scribble/manual
+
+@title[#:tag "mock-reference"]{The Mock Reference}
+
+This document describes the complete API of the @racketmodname[mock] library.
+For a gentler introduction and use cases, see @secref{mock-guide}.
+
+@table-of-contents[]
+
+@include-section["base.scrbl"]
+@include-section["args.scrbl"]
+@include-section["check.scrbl"]
+@include-section["opaque.scrbl"]
+@include-section["syntax.scrbl"]
+@include-section["stub.scrbl"]

--- a/private/util-doc.rkt
+++ b/private/util-doc.rkt
@@ -18,6 +18,7 @@ provide
                  mock/rackunit
                  racket/base
                  racket/contract
+                 racket/file
                  racket/function
                  rackunit
 
@@ -29,6 +30,7 @@ require
             mock/rackunit
             racket/base
             racket/contract
+            racket/file
             racket/function
             rackunit
 
@@ -48,7 +50,7 @@ require
 
 (define (make-mock-eval)
   (make-base-eval #:lang 'racket/base
-                  '(require mock mock/rackunit racket/format racket/function)))
+                  '(require mock mock/rackunit racket/format racket/function racket/file)))
 
 (define-syntax-rule (mock-examples example ...)
    (examples #:eval (make-mock-eval) example ...))

--- a/private/util-doc.rkt
+++ b/private/util-doc.rkt
@@ -18,6 +18,7 @@ provide
                  mock/rackunit
                  racket/base
                  racket/contract
+                 racket/function
                  rackunit
 
 require
@@ -28,6 +29,7 @@ require
             mock/rackunit
             racket/base
             racket/contract
+            racket/function
             rackunit
 
 (define-simple-macro (define-techs [key:str use-id:id def-id:id] ...)

--- a/private/util-doc.rkt
+++ b/private/util-doc.rkt
@@ -7,6 +7,7 @@ provide
   define-behavior-tech
   define-mock-tech
   define-opaque-tech
+  define-persistent-mock-examples
   define-stub-tech
   mock-examples
   mock-tech
@@ -49,3 +50,9 @@ require
 
 (define-syntax-rule (mock-examples example ...)
    (examples #:eval (make-mock-eval) example ...))
+
+(define-syntax-rule (define-persistent-mock-examples id)
+  (begin
+    (define shared-eval (make-mock-eval))
+    (define-syntax-rule (id example (... ...))
+      (examples #:eval shared-eval example (... ...)))))


### PR DESCRIPTION
Closes #10. Partially. This is a guide for the main components of the mock library - mocks, behaviors, and `define/mock`. Further sections should be added for stubs and opaque values.
