### PR TITLE
Add check-mock-calls

### DIFF
--- a/mock-rackunit/info.rkt
+++ b/mock-rackunit/info.rkt
@@ -14,3 +14,5 @@
 (define test-omit-paths
   '(#rx"\\.scrbl$"
     #rx"info\\.rkt$"))
+(define cover-omit-paths
+  '("rackunit.rkt"))

--- a/mock-rackunit/info.rkt
+++ b/mock-rackunit/info.rkt
@@ -13,5 +13,4 @@
     "sweet-exp"))
 (define test-omit-paths
   '(#rx"\\.scrbl$"
-    #rx"info\\.rkt$"
-    #rx"util-doc\\.rkt$"))
+    #rx"info\\.rkt$"))

--- a/mock-rackunit/info.rkt
+++ b/mock-rackunit/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 (define collection "mock")
 (define scribblings '(("rackunit.scrbl" () (library) "mock-rackunit")))
-(define version "1.0")
+(define version "1.1")
 (define deps
   '(("base" #:version "6.4")
     ("mock" #:version "1.0")

--- a/mock-rackunit/rackunit.rkt
+++ b/mock-rackunit/rackunit.rkt
@@ -1,12 +1,49 @@
 #lang sweet-exp racket/base
 
-provide check-mock-called-with?
+provide check-mock-calls
+        check-mock-called-with?
         check-mock-num-calls
 
-require rackunit
+require racket/list
+        rackunit
+        syntax/parse/define
         mock
 
+(define-simple-macro (with-check-info/id (id:id ...) body ...+)
+  (with-check-info (['id id] ...) body ...))
+
 (define no-calls-made-message "No calls were made matching the expected arguments")
+
+(define-check (check-mock-calls mock expected-call-args-list)
+  (define actual-num-calls (mock-num-calls mock))
+  (define expected-num-calls (length expected-call-args-list))
+  (define actual-call-args-list (map mock-call-args (mock-calls mock)))
+  (with-check-info/id (mock)
+    (with-check-info/id (actual-num-calls expected-num-calls)
+      (when (< actual-num-calls expected-num-calls)
+        (define missing-calls (drop expected-call-args-list (length actual-call-args-list)))
+        (with-check-info/id (missing-calls)
+          (fail-check "Mock called less times than expected")))
+      (when (> actual-num-calls expected-num-calls)
+        (define extra-calls (drop actual-call-args-list (length expected-call-args-list)))
+        (with-check-info/id (extra-calls)
+          (fail-check "Mock called more times than expected"))))
+    (for ([actual-call-args (in-list actual-call-args-list)]
+          [expected-call-args (in-list expected-call-args-list)]
+          [which-call (in-naturals)])
+      (with-check-info/id (which-call actual-call-args expected-call-args)
+        (unless (equal? actual-call-args expected-call-args)
+          (fail-check "Mock called with unexpected arguments"))))))
+
+(module+ test
+  (test-case "Should check that a mocks calls exactly match a given list of arguments"
+    (define void-mock (mock #:name 'void-mock #:behavior void))
+    (check-mock-calls void-mock '())
+    (void-mock 1 2 3)
+    (check-mock-calls void-mock (list (arguments 1 2 3)))
+    (void-mock 'foo)
+    (void-mock 'bar)
+    (check-mock-calls void-mock (list (arguments 1 2 3) (arguments 'foo) (arguments 'bar)))))
 
 (define-check (check-mock-called-with? mock args)
   (with-check-info (['expected-args args]

--- a/mock-rackunit/rackunit.scrbl
+++ b/mock-rackunit/rackunit.scrbl
@@ -14,6 +14,18 @@
 This package provides @racketmodname[rackunit] checks for working with @mock-tech{mocks}
 from the @racketmodname[mock] library.
 
+@defproc[(check-mock-calls [m mock] [args-list (listof arguments)]) void?]{
+ A @racketmodname[rackunit] check that passes if @racket[m] has been called with each
+ @racket[args] in their given order and no other times.
+ @mock-rackunit-examples[
+ (define void-mock (mock #:behavior void))
+ (void-mock 1)
+ (void-mock 'foo)
+ (check-mock-calls void-mock (list (arguments 1)))
+ (check-mock-calls void-mock (list (arguments 1) (arguments 'foo)))
+ (check-mock-calls void-mock (list (arguments 'foo) (arguments 1)))
+ (check-mock-calls void-mock (list (arguments 1) (arguments 'foo) (arguments #:bar "baz")))]}
+
 @defproc[(check-mock-called-with? [m mock?] [args arguments]) void?]{
  A @racketmodname[rackunit] check that passes if @racket[m] has
  been called with @racket[args].


### PR DESCRIPTION
Closes #60.

Unfortunately, rackunit doens't provide a way to make checks of variable arity (see racket/rackunit#17) so `check-mock-calls` needs to accept a list of arguments rather than take them as varargs.
