### PR TITLE
Improve error message for with-mocks identifier

### DIFF
--- a/mock/private/syntax-test.rkt
+++ b/mock/private/syntax-test.rkt
@@ -2,6 +2,7 @@
 
 require racket/function
         rackunit
+        syntax/macro-testing
         "args.rkt"
         "base.rkt"
         "syntax.rkt"
@@ -99,3 +100,11 @@ require racket/function
     (check-pred left? left)
     (check-pred right? right)
     (check-equal? (bar-opaque-multi) (cons left right))))
+
+(test-case "Should raise a syntax error when used with a normal procedure"
+  (define (bar-normal)
+    (foo))
+  (check-equal? (bar-normal) "real")
+  (check-exn #rx"bar-normal not bound with define/mock"
+             (thunk
+              (convert-compile-time-error (with-mocks bar-normal (void))))))


### PR DESCRIPTION
Adds a syntax class for identifiers bound with `define/mock` that fails
with syntax errors when used on identifiers not bound in this manner.
Additionally, moves static information unwrapping logic into this
syntax class and exposes the relevant identifiers through syntax class
attributes.