### PR TITLE
Fix incorrect use of raise-arguments-error

### DIFF
--- a/mock/private/function.rkt
+++ b/mock/private/function.rkt
@@ -66,7 +66,7 @@ module+ test
     (unless (< i (vector-length vec))
       (raise-arguments-error
        'const-series "called more times than number of arguments"
-       'num-calls i))
+       "num-calls" i))
     i)
   (define (index++!) (box-transform! index-box add1))
 


### PR DESCRIPTION
The `raise-arguments-error` function is documented as accepting strings for the fields, not symbols. Looks like Racket BC would silently accept symbols and convert them to strings, but Racket CS no longer does that. Discovered in racket/racket#3457.